### PR TITLE
refactor(OPAL-240) correction to use googleCalendarId instead of goog…

### DIFF
--- a/app/src/main/java/com/greenfox/kalendaryo/adapter/GoogleCalendarAdapter.java
+++ b/app/src/main/java/com/greenfox/kalendaryo/adapter/GoogleCalendarAdapter.java
@@ -67,9 +67,9 @@ public class GoogleCalendarAdapter extends RecyclerView.Adapter<GoogleCalendarAd
             @Override
             public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
                 if (b)
-                    listChange.saveCalendar((String)holder.calendarName.getText());
+                    listChange.saveCalendar(googleCalendar.getId());
                 else {
-                    listChange.removeCalendar((String)holder.calendarName.getText());
+                    listChange.removeCalendar(googleCalendar.getId());
                 }
             }
         });


### PR DESCRIPTION
…leCalendarName

changes in GoogleCalendarAdapter get the id of the google calendar instead of its name